### PR TITLE
fix(config): add htaccess for routing and php sockets extension

### DIFF
--- a/packages/backend/.gitignore
+++ b/packages/backend/.gitignore
@@ -8,3 +8,5 @@
 /var/
 /vendor/
 ###< symfony/framework-bundle ###
+
+composer.phar

--- a/packages/backend/Dockerfile
+++ b/packages/backend/Dockerfile
@@ -13,7 +13,8 @@ RUN docker-php-ext-install \
     intl \
     zip \
     pdo_mysql \
-    pdo 
+    pdo \
+    sockets
 
 RUN a2enmod rewrite
 

--- a/packages/backend/public/.htaccess
+++ b/packages/backend/public/.htaccess
@@ -1,0 +1,8 @@
+<IfModule mod_rewrite.c>
+    Options -MultiViews
+
+    RewriteEngine On
+    RewriteCond %{REQUEST_FILENAME} !-f
+    RewriteRule ^(.*)$ index.php [QSA,L]
+
+</IfModule>


### PR DESCRIPTION
The Sockets extension must be enabled for the AMQP protocol to communicate effectively with RabbitMQ